### PR TITLE
Update wf.py

### DIFF
--- a/waveform/waveform/wf.py
+++ b/waveform/waveform/wf.py
@@ -7,8 +7,8 @@ def makeArrayToSend(b0, F_Burst_Time, Sampling_Freq, Burst_Width, Measuring_Time
 	 
     b0_field_strength = b0 # muT
 
-    gamma_xe = 11.77717 # (10^6 rad*s^-1*T^-1)/(2Pi)=MHz/T
-    gamma_he = 32.4341  # 
+    gamma_xe = 11.77673923 # (10^6 rad*s^-1*T^-1)/(2Pi)=MHz/T - REF: M. Pfeffer, J. Magn. Res., Vol 108, 1994
+    gamma_he = 32.4341008  #  REF Flowers, Metrologia, Vol 30, 1993
     
     volt_per_muT = 17.29                                 ###volt_per_muT = 2*17.29 # V_pp / muT (Rafael)
     


### PR DESCRIPTION
Updated the gyro-magnetic ratios for 129 xenon and 3 helium according to the reference in the line comments. For 3 helium the change is on the 1e-7 level, for xenon it is more significant at 4e-4.
